### PR TITLE
Fix typo in SendTransaction_3.js in dev_contract branch 

### DIFF
--- a/src/app/components/Popup/_22_sendTransaction/SendTransaction_3.js
+++ b/src/app/components/Popup/_22_sendTransaction/SendTransaction_3.js
@@ -126,7 +126,7 @@ class SendTransaction3 extends Component {
       }
       default:
         break;
-    }note
+    }
   }
 
   getErrorText = () => {


### PR DESCRIPTION
The build currently fails with the following error : 

> ERROR in ./src/app/components/Popup/_22_sendTransaction/SendTransaction_3.js
>  Line 129:  'note' is not defined  no-undef