### PR TITLE
Fix a minor typo

### DIFF
--- a/src/constants/i18n/en.js
+++ b/src/constants/i18n/en.js
@@ -159,7 +159,7 @@ export default {
     alertLTMin: (min, type) => `The minimum amount of ${type} is ${min}.`,
     alertGTMax: (max, type) => `The maximum amount of ${type} is ${max}.`,
     alertNoChange: 'There is no changed in amount.',
-    alertFull: 'There is no ICX left. Please check the ICX remainig amount.',
+    alertFull: 'There is no ICX left. Please check the ICX remaining amount.',
   },
 
   currency: {


### PR DESCRIPTION
https://github.com/icon-project/iconex_chrome_extension/blob/57a330d525bfda6800646b9287dcef8983ae27e8/src/constants/i18n/en.js#L162

`remainig` should be `remaining`