### PR TITLE
Change the method of CPS SCORE.

### DIFF
--- a/src/redux/api/pRepIissApi.js
+++ b/src/redux/api/pRepIissApi.js
@@ -175,12 +175,12 @@ export async function getCPSData() {
     if (ICX_CPS_SCORE()) {
       const getPRepsRes = await icx_call({
         contractAddress: ICX_CPS_SCORE(),
-        methodName: "get_PReps",
+        methodName: "getPReps",
         inputObj: {},
       });
       const getSponsorsRecordRes = await icx_call({
         contractAddress: ICX_CPS_SCORE(),
-        methodName: "get_sponsors_record",
+        methodName: "getSponsorsRecord",
         inputObj: {},
       });
       return {

--- a/src/redux/sagas/pRepIissSaga.js
+++ b/src/redux/sagas/pRepIissSaga.js
@@ -64,7 +64,7 @@ function* getPRepDataFunc({ options }) {
       _payload.preps = _payload.preps.map((prep) => ({
         ...prep,
         governance: !!governance[prep.address],
-        sponsoredProjects: sponsoredProjects[prep.address] || 0,
+        sponsoredProjects: Number(sponsoredProjects[prep.address]) || 0,
       }));
       yield put({
         type: AT.getPRepDataFulfilled,


### PR DESCRIPTION
The method name of CPS SCORE has changed, causing the PRep list not to appear on the voting page. 
I have updated the code with the changed method name.
And I converted the hex value to a number.

https://tracker.icon.community/contract/cx9f4ab72f854d3ccdc59aa6f2c3e2215dd62e879f#contract
